### PR TITLE
add links to feed and autodiscovery

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -52,6 +52,7 @@ footer:
   ifsub: Check out our Telegram channel to stay up to date on Firo news.
   newsbutton: Read news
   comm: communication
+  feed: Feed RSS
   
 home:
   heading: Privacy is consent

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,6 +14,7 @@
                   <div class="col">
                       <h4>{% t footer.website %}</h4>
                       <ul>
+                          <li><a href="{{ site.baseurl }}/feed.xml">{% t footer.feed %}</a></li>
                           <li><a href="{{ site.baseurl }}/privacy-policy/">{% t footer.privacy %}</a></li>
                           <li><a href="">{% t footer.tos %}</a></li>
                       </ul>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,4 +16,6 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/img/meta/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/img/meta/favicon-16x16.png">
     <link rel="manifest" href="img/meta/site.webmanifest">
+    <!-- Feed autodiscovery -->
+    {% feed_meta %}
 </head>


### PR DESCRIPTION
The rss feed plugin was added with #242, but without references or links people cannot use it.

This pr adds a link in the footer and support for autodiscovery, so that it's enough to add `firo.org` in a feed aggregator and the link to Firo's feed will be discovered automatically.

I wanted to add an icon in the footer but had issues (see #247). Ideally, we want to add at least an icon somewhere in the footer and maybe on the blog page as well.