### PR TITLE
workflows: add basic ci in .github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: Build with Jekyll
+
+on: [push, pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: false
+      - name: install bundler
+        run: gem install bundler
+      - name: bundle install
+        run: bundle install
+      - name: build website
+        run: bundle exec jekyll build


### PR DESCRIPTION
Basic CI using github actions to make sure master and incoming PRs are not going to break the website. It runs only on ruby 3.1, but we can add more versions if we want.