### PR TITLE
home: add missing alt texts and lazy loading of images

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,10 @@ permalink: /index.html
               <section id="intro">
           <div class="row">
               <div class="intro-img col">
-                  <img src="/img/firo-ecosystem.svg"/>
+                  <img src="/img/firo-ecosystem.svg" alt="Image representing the Firo ecosystem"/>
               </div>
               <div class="intro-info col imgi">
-                  <img src="/img/img_firo-mobile-top2.svg"/>
+                  <img src="/img/img_firo-mobile-top2.svg" alt="Header for mobile" loading="lazy"/>
               </div>
               <div class="intro-info col">
                   <h1>{% t home.heading %}</h1>
@@ -18,7 +18,7 @@ permalink: /index.html
                   <a class="btn-secondary" href="{{ site.baseurl }}/about/faq/">{% t home.cta2 %}</a>
               </div>
               <div class="intro-info col imgi">
-                  <img src="/img/img_firo-mobile-bot2.svg"/>
+                  <img src="/img/img_firo-mobile-bot2.svg" alt="Header for mobile" loading="lazy"/>
               </div>
           </div>
       </section>
@@ -27,21 +27,21 @@ permalink: /index.html
          <div class="container">
           <div class="row blockchain">
              <div class="col col-img">
-                  <img src="/img/privacy.svg" alt="Blockchain illustration"/>
+                  <img src="/img/privacy.svg" alt="Blockchain illustration" loading="lazy"/>
              </div>
              <div class="col col-info">
                   <h3>{% t home.privacy %}</h3>
                   <p>{% t home.privacy1 %}</p>
                   <div class="row block-facts">
                       <div class="col">
-                         <img src="/img/site-icons/icon_anonymous.svg" alt="" />
+                         <img src="/img/site-icons/icon_anonymous.svg" alt="stylised human figure with an exclamation mark on the face" loading="lazy"/>
                          <div>
                               <h4>{% t home.privacy2 %}</h4>
                               <p>2<sup>16</sup></p>
                           </div>
                       </div>
                       <div class="col">
-                          <img src="/img/site-icons/icon_setup.svg" alt="" />
+                          <img src="/img/site-icons/icon_setup.svg" alt="stylised equalizer" loading="lazy"/>
                           <div>
                               <h4>{% t home.privacy3 %}</h4>
                               <p>{% t global.yeth %}</p>
@@ -56,21 +56,21 @@ permalink: /index.html
                   <p>{% t home.blockchain1 %}</p>
                   <div class="row block-facts">
                       <div class="col">
-                          <img src="/img/site-icons/icon_coins.svg" alt="" />
+                          <img src="/img/site-icons/icon_coins.svg" alt="stylised stack of coins" loading="lazy"/>
                           <div>
                               <h4>{% t home.blockchain2 %}</h4>
                               <p>21.4 mil</p>
                           </div>
                       </div>
                       <div class="col">
-                          <img src="/img/site-icons/icon_axe.svg" alt="" />
+                          <img src="/img/site-icons/icon_axe.svg" alt="stylised axe" loading="lazy"/>
                           <div>
                                <h4>{% t home.blockchain3 %}</h4>
                                <p>FiroPoW</p>
                            </div>
                       </div>
                       <div class="col">
-                          <img src="/img/site-icons/icon_node.svg" alt="" />
+                          <img src="/img/site-icons/icon_node.svg" alt="stylised stack of servers representing nodes" loading="lazy"/>
                           <div>
                               <h4>{% t home.blockchain4 %}</h4>
                               <p>5000+</p>
@@ -79,12 +79,12 @@ permalink: /index.html
                   </div>
              </div>
              <div class="col col-img">
-                  <img src="/img/blockchain.svg" alt="Blockchain illustration"/>
+                  <img src="/img/blockchain.svg" alt="Blockchain illustration" loading="lazy"/>
              </div>
           </div>
           <div class="row blockchain">
              <div class="col col-img">
-                  <img src="/img/privacy-infrastructure.svg" alt="Privacy Infrastructure illustration"/>
+                  <img src="/img/privacy-infrastructure.svg" alt="Privacy Infrastructure illustration" loading="lazy"/>
              </div>
              <div class="col col-info">
                   <h3>{% t home.privacyin %}</h3>
@@ -97,22 +97,22 @@ permalink: /index.html
                   <p>{% t home.randd1 %}</p>
                   <div class="row block-facts">
                       <div class="col">
-                         <img src="/img/site-icons/icon_sigma.svg" alt="" />
+                         <img src="/img/site-icons/icon_sigma.svg" alt="stylised sigma" loading="lazy"/>
                          <h4>Sigma</h4>
                       </div>
                       <div class="col">
-                          <img src="/img/site-icons/icon_lelantus.svg" alt="" />
+                          <img src="/img/site-icons/icon_lelantus.svg" alt="stylised L" loading="lazy"/>
                           <h4>Lelantus</h4>
                       </div>
                       <div class="col">
-                          <img src="/img/site-icons/icon_dandelion.svg" alt="" />
+                          <img src="/img/site-icons/icon_dandelion.svg" alt="stylised dandelion" loading="lazy"/>
                           <h4>Dandelion</h4>
                       </div>
                   </div>
                   <a class="btn-secondary" href="{{ site.baseurl }}/about/research/">{% t home.cta2 %}</a>
              </div>
              <div class="col col-img">
-                  <img src="/img/rnd.svg" alt="Blockchain illustration"/>
+                  <img src="/img/rnd.svg" alt="Blockchain illustration" loading="lazy"/>
              </div>
           </div>
           </div>
@@ -128,21 +128,21 @@ permalink: /index.html
           </div>
           <div class="row btns">
              <a class="col" href="{{ site.baseurl }}/get-firo/download/">
-                  <img src="/img/wallet.svg" alt="" />
+                  <img src="/img/wallet.svg" alt="Image representing a physical Firo wallet" loading="lazy"/>
                   <h3>{% t home.getfiro2 %}</h3>
              </a>
              <a class="col" href="{{ site.baseurl }}/get-firo/buy-firo/">
-                  <img src="/img/buy-firo.svg" alt="" />
+                  <img src="/img/buy-firo.svg" alt="Image representing swapping Firo for dollars" loading="lazy"/>
                   <h3>{% t home.getfiro3 %}</h3>
              </a>
              
              <a class="col" href="{{ site.baseurl }}/guide/masternode-setup.html">
-                  <img src="/img/earn-firo.svg" alt="" />
+                  <img src="/img/earn-firo.svg" alt="Image representing a masternode" loading="lazy"/>
                   <h3>{% t home.getfiro4 %}</h3>
              </a>
              
              <a class="col" href="{{ site.baseurl }}/guide/how-to-mine-firo.html">
-                  <img src="/img/mine-firo.svg" alt="" />
+                  <img src="/img/mine-firo.svg" alt="Image showing a pickaxe representing mining Firo" loading="lazy"/>
                   <h3>{% t home.getfiro5 %}</h3>
              </a>
           </div>


### PR DESCRIPTION
Alt fields are very important and should be added for every image on the website. They allow visually impaired users to browse the website comfortably and increase the SEO score.

Lazy loading makes the initial loading of the page much faster, resulting in a smoother experience for users, especially those with poor internet connections.

Both `alt` fields and lazy loading should be added on every page of the website, starting with the most important/visited pages