### PR TITLE
faq: remove embedded youtube video

### DIFF
--- a/about/faq/index.html
+++ b/about/faq/index.html
@@ -242,7 +242,7 @@ permalink: /about/faq/index.html
                             <div class="tab-content">
                                 <p>FiroPoW is a mining algorithm that&nbsp;is highly optimized for GPU mining and designed to be both FPGA and ASIC resistant to even the playing field and allow people to mine from their own consumer hardware. We have always been big fans of Proof of Work’s ability to tie the value of a virtual currency to the real world along with a way to distribute Firo’s supply in a fair and decentralized manner free from restrictions.</p>
                                 <p>FiroPoW follows <a href="https://github.com/ifdefelse/ProgPOW">ProgPoW’s 0.9.4</a> spec with a small change to have the algorithm randomly change with every block. The starting DAG size will be slightly over 4GB and will increase by 8MB every 1300 blocks (~4.5 days). This DAG size has been chosen to support most modern graphics cards.</p>
-                                <div class="iframe-embed"><iframe src="https://www.youtube.com/embed/DAJirQaBIzY?feature=oembed&amp;wmode=transparent" allowfullscreen="" data-aspectratio="0.562962962962963" style="width: 0px; height: 0px; opacity: 1; visibility: visible;" frameborder="0"></iframe></div>
+                                <p>There is a visual explanation of the Merkle Tree Proof algorithm in Firo (formerly Zcoin) <a href="https://www.youtube.com/watch?v=DAJirQaBIzY">on Youtube</a></p>
                             </div>
                           </div>
                           <div class="tab">


### PR DESCRIPTION
Embedding youtube videos results in youtube creeping in the page with trackers and ads, better add a simple link. Especially since "Firefox's tracking detection" hides the embedded youtube video by default (so firefox users don't even see it)