### PR TITLE
home: bring back 'learn more' button for mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -819,11 +819,15 @@ a.btn-primary, a.btn-secondary {
 }
     
 #intro .intro-info a.btn-secondary {
-    margin-left: 0;
+    margin-bottom: 3rem;
+    margin-left: auto;
+    margin-right: auto;
 }
     
 #intro .intro-info a.btn-secondary, #intro .intro-info a.btn-primary {
     margin-top: 1.5rem;
+    margin-left: auto;
+    margin-right: auto;
 }
     
 }
@@ -852,12 +856,8 @@ a.btn-primary, a.btn-secondary {
     padding: 0;
 }
     
-#intro a.btn-secondary {
-    display: none;
-}
-    
 #intro a.btn-primary {
-    margin-bottom: 3rem;
+    margin-bottom: 1rem;
     margin-left: auto;
     margin-right: auto;
 }


### PR DESCRIPTION
The 'Learn More' button was intentionally disabled on mobile. I couldn't see a reason, so i brought it back. Let me know if i missed something.


![Screenshot_20231116_101905](https://github.com/firoorg/firo-site/assets/28106476/efa671f9-b83a-4e92-8da4-e17e65ff4fcf)
![Screenshot_20231116_101818](https://github.com/firoorg/firo-site/assets/28106476/352207a7-00b2-42c3-8022-b69541ed0755)
