### PR TITLE
add troubleshooting-masternode guide and fix links

### DIFF
--- a/guide/index.html
+++ b/guide/index.html
@@ -31,11 +31,11 @@ permalink: /guide/index.html
                         <h2>Wallet</h2>
                         <ul class="guides-list">
                             <li><a href="{{ site.baseurl_root}}/2024/02/05/firoqt-guide-spark.html">Firo-QT Wallet Guide</a></li>
-                            <li><a href="/guide/common-problems.html">Common wallet problems</a></li>
-                            <li><a href="/guide/backing-up-firo-wallet-with-recovery-seed-phrase.html">How to backup your Firo wallet with a recovery seed phrase</a></li>
-                            <li><a href="/guide/reindex-wallet.html">Reindexing your Firo wallet</a></li>
-							<li><a href="/guide/using-ledger-with-firo.html">How to Use Ledger With Firo</a></li>
-                            <li><a href="/guide/using-trezor-with-firo.html">How to Use Trezor With Firo</a></li>
+                            <li><a href="{{ site.baseurl }}/guide/common-problems.html">Common wallet problems</a></li>
+                            <li><a href="{{ site.baseurl }}/guide/backing-up-firo-wallet-with-recovery-seed-phrase.html">How to backup your Firo wallet with a recovery seed phrase</a></li>
+                            <li><a href="{{ site.baseurl }}/guide/reindex-wallet.html">Reindexing your Firo wallet</a></li>
+							<li><a href="{{ site.baseurl }}/guide/using-ledger-with-firo.html">How to Use Ledger With Firo</a></li>
+                            <li><a href="{{ site.baseurl }}/guide/using-trezor-with-firo.html">How to Use Trezor With Firo</a></li>
                         </ul>
                   </div>
               </div>
@@ -48,7 +48,7 @@ permalink: /guide/index.html
                   <div class="col">
                         <h2>Mining</h2>
                         <ul class="guides-list">
-                            <li><a href="/guide/how-to-mine-firo.html">How to Mine Firo (FIRO) with FiroPoW</a></li>
+                            <li><a href="{{ site.baseurl }}/guide/how-to-mine-firo.html">How to Mine Firo (FIRO) with FiroPoW</a></li>
                         </ul>
                   </div>
               </div>
@@ -61,9 +61,10 @@ permalink: /guide/index.html
                   <div class="col">
                         <h2>Masternode</h2>
                         <ul class="guides-list">
-                            <li><a href="/guide/masternode-setup.html">Firo masternode setup guide</a></li>
-                            <li><a href="/guide/masternode-upgrade.html">Upgrading your Firo masternode</a></li>
-                            <li><a href="/guide/reindex-wallet.html">Reindexing your Firo wallet</a></li>
+                            <li><a href="{{ site.baseurl }}/guide/masternode-setup.html">Firo masternode setup guide</a></li>
+                            <li><a href="{{ site.baseurl }}/guide/masternode-upgrade.html">Upgrading your Firo masternode</a></li>
+                            <li><a href="{{ site.baseurl }}/guide/reindex-wallet.html">Reindexing your Firo wallet</a></li>
+                            <li><a href="{{ site.baseurl }}/guide/troubleshooting-masternode.html">Troubleshooting masternode: PoSe score and PoSe ban</a></li>
                         </ul>
                   </div>
               </div>
@@ -76,7 +77,7 @@ permalink: /guide/index.html
                   <div class="col">
                         <h2>Privacy Tech</h2>
                         <ul class="guides-list">
-                            <li><a href="/guide/privacy-coin-comparison.html">How Firo's Privacy Technology Compares to the Competition</a></li>
+                            <li><a href="{{ site.baseurl }}/guide/privacy-coin-comparison.html">How Firo's Privacy Technology Compares to the Competition</a></li>
                         </ul>
                   </div>
               </div>
@@ -89,7 +90,7 @@ permalink: /guide/index.html
                   <div class="col">
                         <h2>DeFi</h2>
                         <ul class="guides-list">
-                            <li><a href="/guide/liquidity-firo-pancakeswap.html">How to Provide Liquidity for Firo on Pancakeswap</a></li>
+                            <li><a href="{{ site.baseurl }}/guide/liquidity-firo-pancakeswap.html">How to Provide Liquidity for Firo on Pancakeswap</a></li>
                         </ul>
                   </div>
               </div>

--- a/guide/masternode-setup.md
+++ b/guide/masternode-setup.md
@@ -434,7 +434,7 @@ operatorPayoutAddress: "" , if you set your operatorReward to 0 during registrat
 feeSourceAddress: an address in the local wallet that has FIRO to fund the transaction. Can be obtained with the listaddressbalances command
 ```
 
-Please ensure that you have fixed the problem that caused the ban before unbanning your masternode otherwise it will get banned again. [A more detailed guide is here.](https://github.com/firoorg/firo/wiki/Troubleshooting-masternode%3A-PoSe-score-and-PoSe-ban)
+Please ensure that you have fixed the problem that caused the ban before unbanning your masternode otherwise it will get banned again. [A more detailed guide is available]({{ site.baseurl }}/guide/troubleshooting-masternode.html).
 
 After unbanning, ensure that you check the status of the masternode in both the wallet and **the masternode itself.** Failure to do this will cause another ban as you just unbanned your masternode on the network but did not fix the problem that caused it to be banned in the first place.
 

--- a/guide/troubleshooting-masternode.md
+++ b/guide/troubleshooting-masternode.md
@@ -1,0 +1,90 @@
+---
+layout: guide
+title: "Troubleshooting masternode: PoSe score and PoSe ban"
+summary: 
+tags: [guide]
+author: "Firo Team"
+permalink: /guide/troubleshooting-masternode.html
+---
+
+Masternode quorums form at certain block heights. When reaching such height, a subset of currently enabled masternodes is selected for participation in the quorum. This subset is chosen deterministically, meaning every peer on the network chooses exactly the same subset. A series of messages are then sent between quorum members to generate cryptographic keys. 
+
+Only masternodes that are configured correctly and running at the time of quorum formation can participate in key generation. If the masternode is selected for quorum but is misconfigured, not running or did not participate, it will be penalised. The masternode will gain a PoSe score which is given by `66% x number of Enabled masternodes` or `100`, whichever is greater.
+
+The PoSe score decreases by 1 for every block mined. A masternode with a PoSe score of 3000 therefore requires 3000 blocks to be mined before its score is zeroed.
+
+Once the PoSe score reaches **more than the total number of masternodes,** it changes status to PoSe Banned and needs to be restarted with `protx update_service` after any problems on the masternode is fixed.
+
+## Troubleshooting
+
+_(This list is non-exhaustive. Your masternode might be facing a problem that is not listed here.)_
+
+* Running out of disk space
+
+* Running out of swap space
+
+* firod not running
+
+* Insufficient number of connections to other masternodes
+
+* Wrong/missing `znodeblsprivkey` in `firo.conf`
+
+* `znodeblsprivkey=` is wrongly typed as `znodeblskey=` etc
+
+* Not restarting firod after modifying `firo.conf`
+
+* Stuck on a block
+
+* IP used when registering masternode is not the same as the IP the masternode is running on
+
+* IPv4/IPv6 interface related problems
+
+* Problems with the datacenter
+
+When everything is configured correctly, `./firo-cli evoznode status` and ``./firo-cli getinfo` will return
+
+```
+  "state": "READY",
+  "status": "Ready"
+```
+
+and the **[current block number](https://explorer.firo.org/)** along with other masternode-related status if ENABLED, or
+
+```
+  "state": "POSE_BANNED",
+  "status": "Znode was PoSe banned"
+```
+
+if the masternode is POSE_BANNED.
+
+## Restarting your PoSe Banned masternode
+
+**The following commands must be performed on your wallet. Performing it on your masternode will not work as there is no balance to cover the transaction fee.**
+
+After you have ensured that everything is correct, bring back your PoSe banned masternode to Enabled with this command:
+
+```
+protx update_service proTxHash ipAndPort operatorKey operatorPayoutAddress feeSourceAddress
+```
+
+Before you are able to enter the command, you must first unlock your wallet:
+
+```
+walletpassphrase "YOUR PASSWORD" 60
+```
+
+This command will unlock your wallet for 60 seconds and returns a `(null)` message when successfully executed.
+
+`proTxHash`: original output of `protx register` command. In masternodes tab, right-click on the banned node and choose 'Copy Protx hash'.
+
+`ipAndPort`: ipAndPort of banned masternode
+
+`operatorKey`: znodeblsprivkey of the masternode
+
+`operatorPayoutAddress`: "" (if you set your operatorReward to 0)
+
+`feeSourceAddress`: an address in wallet that has a balance to fund the transaction
+
+This command will output a transaction ID which can then be checked at [explorer.firo.org](https://explorer.firo.org). Your node will return to Enabled after the transaction is mined.
+
+**WARNING:** Do not change `operatorKey` if you are only reviving the banned masternode.


### PR DESCRIPTION
- migrate guide "Troubleshooting masternode: PoSe score and PoSe ban" from wiki on github to website
- add baseurl to all links in /guide/index.html
- adapt existing links to the guide

After this is merged, the wiki entry on github needs to be removed: https://github.com/firoorg/firo/wiki/Troubleshooting-masternode%3A-PoSe-score-and-PoSe-ban