### PR TITLE
add guide to setup system service for masternode

### DIFF
--- a/guide/index.html
+++ b/guide/index.html
@@ -66,6 +66,7 @@ permalink: /guide/index.html
                             <li><a href="{{ site.baseurl }}/guide/masternode-upgrade.html">Upgrading your Firo masternode</a></li>
                             <li><a href="{{ site.baseurl }}/guide/reindex-wallet.html">Reindexing your Firo wallet</a></li>
                             <li><a href="{{ site.baseurl }}/guide/troubleshooting-masternode.html">Troubleshooting masternode: PoSe score and PoSe ban</a></li>
+                            <li><a href="{{ site.baseurl }}/guide/masternode-system-managers.html">Set up your masternode with a system manager</a></li>
                         </ul>
                   </div>
               </div>

--- a/guide/masternode-setup.md
+++ b/guide/masternode-setup.md
@@ -441,7 +441,7 @@ After unbanning, ensure that you check the status of the masternode in both the 
 ### Additional tips
 
 The following tips are not covered by this guide but can ensure smoother running of your masternode.
-* Ensure that your masternode is automatically started after a VPS reboot using [systemd](https://github.com/firoorg/firo/wiki/Configuring-masternode-with-systemd)
+* Ensure that your masternode is automatically started after a VPS reboot using [systemd or monit]({{ site.baseurl }}/guide/masternode-system-managers.html)
 * Set Ubuntu to automatically download and install new upgrades
 * Further secure your masternode by modifying the SSH configuration file and/or install and configure fail2ban
 * [Prevent the debug.log from getting too big by rotating it](https://github.com/firoorg/firo/wiki/Configuring-logrotate-for-Firo%27s-debug.log)

--- a/guide/masternode-system-managers.md
+++ b/guide/masternode-system-managers.md
@@ -1,0 +1,137 @@
+---
+layout: guide
+title: Set up your masternode with a system manager
+summary: Guide to set up a masternode with a system manager
+tags: [guide]
+author: "Firo Team"
+permalink: /guide/masternode-system-managers.html
+---
+
+This guide gives instructions on how to set up two popular system managers to simplify and automate the management of your Firo masternode: Systemd and Monit. **Use only one of the two**.
+
+## Systemd
+
+Create a service file for firod:
+
+`sudo nano /etc/systemd/system/firod.service`
+
+Enter the following. Modify the `User`, `Group`, `PIDFile`, `ExecStart`, and `ExecStop` lines according to your own configuration:
+
+```
+[Unit]
+Description=Firo daemon
+After=network.target
+
+[Service]
+Type=forking
+Restart=always
+RestartSec=30
+
+User=username
+Group=username
+PIDFile=/home/username/.firo/firod.pid
+
+ExecStart=/usr/local/bin/firod
+ExecStop=/usr/local/bin/firo-cli stop
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Reload systemd:
+
+`sudo systemctl daemon-reload`
+
+Start firod with systemctl to test
+
+`sudo systemctl start firod.service`
+
+Then check if running with `./firo-cli getinfo`
+
+To enable firod autostart at restart
+
+`sudo systemctl enable firod.service`
+
+To stop firod (e.g. to update)
+
+`sudo systemctl stop firod.service`
+
+You can restart firod with
+
+`sudo systemctl restart firod.service`
+
+## Monit
+
+Install monit if not installed:
+
+```
+sudo apt install monit
+```
+
+Edit monit control file:
+
+```
+sudo nano /etc/monit/monitrc
+```
+
+Remove '#' from the front part of the following lines:
+
+```
+set httpd port 2812 and
+    use address localhost  # only accept connection from localhost
+    allow localhost        # allow localhost to connect to the server and
+    allow admin:monit      # require user 'admin' with password 'monit'
+```
+
+Scroll to the end of the file and add '#' in front of this line:
+
+```
+#include /etc/monit/conf-enabled/*
+```
+
+Create a monit control file for firod.
+
+```
+sudo nano /etc/monit/conf.d/firod
+```
+
+Copy and paste the following into the editor. Make sure to modify the paths to suit your installation. Once done, 'Ctrl+X' to save and exit.
+
+```
+check process firod matching "firod"
+        start program = "/home/USERNAME/firo-0.14.1/bin/firod -daemon -datadir=/home/USERNAME/.firo/"
+                as uid USERNAME and gid USERNAME
+        stop program = "/home/user/firo-0.14.1/bin/firo-cli stop"
+                as uid USERNAME and gid USERNAME
+        if failed host 127.0.0.1 port 8168 type TCP for 2 cycles then restart
+```
+
+Reload monit for changes to take effect.
+
+```
+sudo monit reload
+```
+
+Check if the control file is okay with
+
+```
+sudo monit -t
+```
+
+Start firod with monit
+
+```
+sudo monit start firod
+```
+
+Check monitoring status
+
+```
+sudo monit status
+```
+
+To stop firod with monit
+
+```
+sudo monit stop firod
+```


### PR DESCRIPTION
Migrated and merged two guides in the wiki:

- https://github.com/firoorg/firo/wiki/Configuring-masternode-with-monit
- https://github.com/firoorg/firo/wiki/Configuring-masternode-with-systemd

 After this pr is merged, the two wikis above will need to be removed.