### PR TITLE
downloads: workaround gap in mobile wallets and comments

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1307,7 +1307,7 @@ a.btn-primary, a.btn-secondary {
     margin: 0 1rem;
     -ms-flex-pack: justify;
     -webkit-box-pack: justify;
-    justify-content: space-between;
+    justify-content: space-evenly;
 }
 
 .desk-wallets.mob {

--- a/get-firo/download/index.html
+++ b/get-firo/download/index.html
@@ -33,6 +33,7 @@ permalink: /get-firo/download/index.html
                     <div class="col">
                         <p class="tagline">{% t download.option1 %}</p>
                         <div class="inner">
+                            <!-- QT wallet -->
                             <h3>{% t download.qt %}</h3>
                             <p class="wversion">v{{ site.data.downloads.firo_qt_version }}</p>
                             <p class="changelog"><a href="https://github.com/firoorg/firo/releases/latest" target="_blank">{% t download.changelog %}</a></p>
@@ -72,6 +73,7 @@ permalink: /get-firo/download/index.html
                         </div>
                     </div>
                     
+                    <!-- Electron -->
                     <div class="col">
                         <p class="tagline">{% t download.option2 %}</p>
                         <div class="inner">
@@ -115,6 +117,7 @@ permalink: /get-firo/download/index.html
                     </div>
                     </div>
                     
+                    <!-- Electrum -->
                     <div class="col">
                         <p class="tagline">{% t download.option3 %}</p>
                         <div class="inner">
@@ -163,6 +166,7 @@ permalink: /get-firo/download/index.html
           </div>
       </section>
       
+      <!-- Mobile wallets -->
       <section class="tech-section">
             <div class="container">
               <div class="row">
@@ -208,6 +212,7 @@ permalink: /get-firo/download/index.html
           </div>
       </section>
       
+      <!-- Third party wallets -->
       <section class="tech-section">
             <div class="container">
               <div class="row">


### PR DESCRIPTION
This is just a temporary workaround to fix the empty gap between the two boxes. The page needs some deep restructuring. I also added a couple of comments in the page to make a bit easier to navigate across sections.