### PR TITLE
custom-url -> pages-base-url

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -30,5 +30,5 @@ jobs:
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: _site
-          custom-url: firoorg.github.io/firo-site
+          pages-base-url: firoorg.github.io/firo-site
           


### PR DESCRIPTION
Update input parameter with `pages-base-url`, remove deprecated `custom-url` 
https://github.com/rossjrw/pr-preview-action/pull/97/commits/3fc0990f8fa3530688e1b9add986c2b97735cc52