### PR TITLE
Campfire Linux link fix

### DIFF
--- a/get-firo/download/index.html
+++ b/get-firo/download/index.html
@@ -121,7 +121,7 @@ permalink: /get-firo/download/index.html
                               </div>
                             </div>
                             <div class="system linux">
-                                <a href="https://github.com/firoorg/campfire/releases/download/v{{ site.data.downloads.campfire_version }}/campfire-v{{ site.data.downloads.campfire_version}}.AppImage">{% t download.downloadcampfirel %}</a>
+                                <a href="https://github.com/firoorg/campfire/releases/download/v{{ site.data.downloads.campfire_version }}/campfire-v{{ site.data.downloads.campfire_version}}-linux.AppImage">{% t download.downloadcampfirel %}</a>
                                 <div class="tab">
                                     <input type="checkbox" id="lh2">
                                     <label class="tab-label" for="lh2">{% t download.hasheslinux %}</label>
@@ -345,3 +345,4 @@ permalink: /get-firo/download/index.html
               </div>
           </div>
       </section>
+


### PR DESCRIPTION
added `-linux` after campfire version