### PR TITLE
Fix formatting and CSS issues from the 2026 redesign

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1305,10 +1305,15 @@ a.btn-primary, a.btn-secondary {
     z-index: 1;                    /* keep text/image above the particles */
 }
  
+/* image left, quote right */
 #manifesto .manifesto-band {
     display: -webkit-box;
     display: -ms-flexbox;
     display: flex;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: reverse;
+    -ms-flex-direction: row-reverse;
+    flex-direction: row-reverse;
     -webkit-box-align: center;
     -ms-flex-align: center;
     align-items: center;
@@ -1316,12 +1321,12 @@ a.btn-primary, a.btn-secondary {
     -ms-flex-pack: justify;
     justify-content: space-between;
 }
- 
+
 #manifesto .manifesto-quote {
     -webkit-box-flex: 1;
     -ms-flex: 1.15 1 0%;
     flex: 1.15 1 0%;               /* quote gets a touch more room than the image */
-    padding-right: 2rem;
+    padding-left: 2rem;
 }
  
 #manifesto .manifesto-quote blockquote {
@@ -1370,7 +1375,7 @@ a.btn-primary, a.btn-secondary {
         text-align: center;
     }
     #manifesto .manifesto-quote {
-        padding-right: 0;
+        padding-left: 0;
         margin-bottom: 2.5rem;
     }
     #manifesto .manifesto-quote blockquote { font-size: 1.7rem; }
@@ -1810,6 +1815,11 @@ a.btn-primary, a.btn-secondary {
     }
     .pillar-page h1 { font-size: 2.2rem; }
     .pillar-page h2 { font-size: 1.7rem; }
+    .pillar-table {
+        display: block;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
 }
 
 /* tint band utility + centered section heading */
@@ -2937,6 +2947,8 @@ img.pillar-mock-logo {
     display: -webkit-box;
     display: -ms-flexbox;
     display: flex;
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     justify-content: center;
@@ -5558,10 +5570,22 @@ br.brmob {
     background-position: center bottom -1rem, center top, top left;
     background-size: 18rem auto, cover, 100% 100%;
 }
- 
+
+}
+
+@media only screen and (max-width: 48rem) {
+
+#intro .intro-info h1 {
+    font-size: 4rem;
+}
+
 }
 
 @media only screen and (max-width: 30rem) {
+
+#intro .intro-info h1 {
+    font-size: 3.5rem;
+}
 
 #introwrap:before {
     background-size: 14rem auto, cover, 100% 100%;
@@ -6362,6 +6386,9 @@ footer .social-icons a img {
         flex: 1 1 0;
         max-width: 100%;
     }
+    #intro-info .row > .col h2 + p {
+        width: auto;
+    }
     #intro-info .row > .col.col-img {
         -ms-flex: 0 0 40%;
         flex: 0 0 40%;
@@ -6380,16 +6407,4 @@ footer .social-icons a img {
 }
 #home #intro-info {
     padding-top: 3rem;
-}
-
-/* manifesto: image left, quote right */
-#manifesto .manifesto-band {
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: reverse;
-    -ms-flex-direction: row-reverse;
-    flex-direction: row-reverse;
-}
-#manifesto .manifesto-quote {
-    padding-right: 0;
-    padding-left: 2rem;
 }

--- a/pillars/private/index.html
+++ b/pillars/private/index.html
@@ -132,8 +132,5 @@ permalink: /pillars/private/index.html
             </div>
         </div>
     </section>
- 
-</div>
-    </section>
-    
+
 </div>


### PR DESCRIPTION
Fixes six formatting/CSS defects introduced by the 2026 redesign (#598/#599 era changes). Each one was confirmed by building the site with Jekyll and rendering the affected pages in a headless browser before and after the fix.

## Fixes

1. **Private pillar page — broken HTML nesting** (`pillars/private/index.html`)
   The page ended with an extra `</section>` and `</div>`, which closed the layout's `<main>` early and left the footer mis-nested. Removed the stray tags; the page now parses as one `<main>` with the footer correctly inside it.

2. **Manifesto section never stacked on mobile** (`css/style.css`)
   A `#manifesto .manifesto-band { flex-direction: row-reverse }` override sat at the very end of the stylesheet, after the `≤48rem` media query that switches the band to a column — so the later rule won at every width and phones showed the quote and image squeezed side by side. Merged the override into the base rule (and moved the quote's `2rem` padding to the correct side) so desktop keeps image-left/quote-right and mobile stacks again.

3. **Hero headline overflowed phone screens**
   The redesign removed the small-screen `#intro .intro-info h1` font sizes, leaving the headline at 6rem (96px) on phones — "revolution" alone was wider than a 375px viewport and forced horizontal page scroll. Restored the ladder: 4rem at `≤48rem`, 3.5rem at `≤30rem`. Verified computed sizes: 96px desktop → 64px at 700px → 56px at 375px.

4. **Comparison table overflowed on mobile** (Private pillar page)
   The 3-column `.pillar-table` was 435px wide on a 375px screen and dragged the whole page sideways. It now scrolls horizontally within itself at `≤48rem`.

5. **Download page overflowed on mobile**
   Third-party wallet cards with four platform icons (Stack, Guarda) could not shrink into the 2-column mobile grid. Added `flex-wrap` to `.dl-tp-platforms`; no effect on desktop where the icons already fit on one line.

6. **Homepage overflowed at ~1024px viewports**
   The legacy `#intro-info h2 + p { width: 37rem }` rule forced a fixed-width paragraph inside the redesign's new flex row, pushing the illustration column past the viewport edge. Neutralized the fixed width inside that layout's `min-width` media query only.

## Verification

- Jekyll build passes.
- Horizontal-overflow sweep: 6 redesigned pages (home, all three pillar pages, download, buy-firo) × 10 viewport widths (360–1920px) = 60 checks, all clean (`scrollWidth == clientWidth`).
- Screenshots confirm hero, manifesto (desktop and mobile), comparison table, third-party wallet grid, and the private page's full structure render as intended.

Not touched (pre-existing / out of scope, noting for awareness): the hardcoded English strings in the homepage "Where to buy / use / earn" cards (no i18n keys exist for them yet), and the `@font-face` for Saira Semi Condensed 300 referencing font files missing from `/fonts` (predates the redesign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Jr3TuZQnPpCJ5QaoSVy4A

---
_Generated by [Claude Code](https://claude.ai/code/session_017Jr3TuZQnPpCJ5QaoSVy4A)_